### PR TITLE
Add landing page for Toolbox

### DIFF
--- a/src/_sidebar.json
+++ b/src/_sidebar.json
@@ -5,7 +5,7 @@
         "text": "Projects", 
         "items": [
             { "text": "QMK Configurator", "link": "https://config.qmk.fm" },
-            { "text": "QMK Toolbox", "link": "https://github.com/qmk/qmk_toolbox" },
+            { "text": "QMK Toolbox", "link": "/toolbox" },
             { "text": "Proton C", "link": "/proton-c" }
         ]
     },

--- a/src/toolbox.md
+++ b/src/toolbox.md
@@ -1,0 +1,29 @@
+---
+layout: home
+hero:
+  name: QMK Toolbox
+  tagline: A collection of flashing tools for QMK keyboards
+  image: /logo.png
+  actions:
+    - theme: brand
+      text: Install for Windows
+      link: https://github.com/qmk/qmk_toolbox/releases/latest/download/qmk_toolbox_install.exe
+    - theme: brand
+      text: Install for macOS
+      link: https://github.com/qmk/qmk_toolbox/releases/latest/download/QMK.Toolbox.pkg
+    - theme: alt
+      text: GitHub
+      link: https://github.com/qmk/qmk_toolbox
+features:
+  - title: Built-In Key Tester
+    icon: ⌨️
+    details: Make sure your newly-flashed keyboard is working as expected.
+  - title: Automatic Driver Installation
+    icon: 🛠️
+    details: No-fuss installation of drivers for all supported bootloaders on Windows.
+  - title: HID Console
+    icon: 🐛
+    details: Debug your code using QMK's Console feature.
+---
+
+[Latest release](https://github.com/qmk/qmk_toolbox/releases/latest) &middot; [Homebrew instructions](https://github.com/qmk/qmk_toolbox?tab=readme-ov-file#download)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

![image](https://github.com/qmk/qmk.fm/assets/4781841/75ad9513-5211-46a7-80ea-58f7fc165e93)

Based on my initial work using Bootstrap:
![image](https://github.com/qmk/qmk.fm/assets/4781841/5197a34c-5f7f-4310-bf7e-6da0d84c96ce)

Seems like some of these things are not possible with this layout, such as the smaller text in and under the buttons, and links in the feature sections. Also not sure about the logo image, I feel like Toolbox needs its own version like MSYS and WSL do. I tried using the screenshot image but it didn't really look right. I'd also probably need to retake it for light/dark mode.