### PR TITLE
Update keyboard link to point to browse.qmk.fm

### DIFF
--- a/src/.vitepress/config.mts
+++ b/src/.vitepress/config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
 
         nav: [
             { text: "Home", link: "/" },
-            { text: "Keyboards", link: "https://github.com/qmk/qmk_firmware/tree/master/keyboards" },
+            { text: "Keyboards", link: "https://browse.qmk.fm" },
             { text: "Docs", link: "https://docs.qmk.fm" }
         ],
         socialLinks: [

--- a/src/_sidebar.json
+++ b/src/_sidebar.json
@@ -1,6 +1,6 @@
 [
     { "text": "Getting Started", "link": "/guide" },
-    { "text": "Supported Keyboards", "link": "https://github.com/qmk/qmk_firmware/tree/master/keyboards" },
+    { "text": "Supported Keyboards", "link": "https://browse.qmk.fm" },
     {
         "text": "Projects", 
         "items": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

https://browse.qmk.fm now replaces the previously broken https://web.archive.org/web/20240523052548/https://qmk.fm/keyboards/ functionality which was removed in the migration. 